### PR TITLE
Copied content from constraint tables to structure definitions 

### DIFF
--- a/input/fsh/facility.fsh
+++ b/input/fsh/facility.fsh
@@ -7,19 +7,48 @@ Profile:      MCSDFacilityOrganization
 Parent:       MCSDOrganization
 Id:           IHE.mCSD.FacilityOrganization
 Title:        "mCSD Organization for Facilities"
-Description:  "A profile on the mCSD Organization profile for mCSD Facilities."
+Description:  """
+A profile on mCSD Organization for mCSD Facilities.
+
+Facilities are physical care delivery sites such as hospitals, clinics, health outposts, physician offices,
+labs, pharmacies, etc. A Facility has a unique identifier, geographic attributes (address, geocode), contact
+attributes, attributes regarding its hours of operation, etc. Each Facility is defined by a pairing of 
+[Location](StructureDefinition-IHE.mCSD.FacilityLocation.html) and
+[Organization](StructureDefinition-IHE.mCSD.FacilityOrganization.html).
+
+In addition to the base requirements of [mCSD Organization](StructureDefinition-IHE.mCSD.Organization.html),
+one `type` must be set to `urn:ietf:rfc:3986#urn:ihe:iti:mcsd:2019:facility`.
+"""
 
 * obeys mcsd-type-1
 * type 2..*
+  * ^short = "One type must be set to: urn:ietf:rfc:3986#urn:ihe:iti:mcsd:2019:facility"
+  * ^definition = "One type must be set to: urn:ietf:rfc:3986#urn:ihe:iti:mcsd:2019:facility"
+
 
 
 Profile:      MCSDFacilityLocation
 Parent:       MCSDLocation
 Id:           IHE.mCSD.FacilityLocation
 Title:        "mCSD Location for Facilities"
-Description:  "A profile on the mCSD Location profile for mCSD Facilities."
+Description:  """
+A profile on mCSD Location for mCSD Facilities.
+
+Facilities are physical care delivery sites such as hospitals, clinics, health outposts, physician offices,
+labs, pharmacies, etc. A Facility has a unique identifier, geographic attributes (address, geocode), contact
+attributes, attributes regarding its hours of operation, etc. Each Facility is defined by a pairing of 
+[Location](StructureDefinition-IHE.mCSD.FacilityLocation.html) and
+[Organization](StructureDefinition-IHE.mCSD.FacilityOrganization.html).
+
+In addition to the base requirements of [mCSD Location](StructureDefinition-IHE.mCSD.Location.html),
+one `type` must be set to `urn:ietf:rfc:3986#urn:ihe:iti:mcsd:2019:facility`.
+"""
 
 * obeys mcsd-type-1
 * type 2..*
+  * ^short = "One type must be set to: urn:ietf:rfc:3986#urn:ihe:iti:mcsd:2019:facility"
+  * ^definition = "One type must be set to: urn:ietf:rfc:3986#urn:ihe:iti:mcsd:2019:facility"
 * managingOrganization 1..1 
 * managingOrganization only Reference(MCSDFacilityOrganization)
+  * ^short = "The reference to the mCSD Organization resource for this facility."
+  * ^definition = "The reference to the mCSD Organization resource for this facility."

--- a/input/fsh/healthcareservice.fsh
+++ b/input/fsh/healthcareservice.fsh
@@ -1,9 +1,28 @@
+
 Profile:      MCSDHealthcareService
 Parent:       HealthcareService
 Id:           IHE.mCSD.HealthcareService
 Title:        "mCSD HealthcareService"
-Description:  "A profile on the HealthcareService resource for mCSD."
+Description:  """
+A profile on the HealthcareService resource for mCSD.
+
+Each healthcare service has a unique identifier. Examples include surgical services, antenatal
+care services, or primary care services. The combination of a Healthcare Service offered at a
+[Location](StructureDefinition-IHE.mCSD.Location.html) may have specific attributes including
+contact person, hours of operation, etc.
+
+"""
 
 * type 1..*
+  * ^short = "The type of service being provided."
+  * ^definition = "The type of service being provided."
 * name 1..1
+  * ^short = "The name of the service being provided."
+  * ^definition = "The name of the service being provided."
+* location only Reference(MCSDLocation)
+  * ^short = "The location where the service is being provided."
+  * ^definition = "The location where the service is being provided."
+* providedBy only Reference(MCSDOrganization)
+  * ^short = "The organization providing this service."
+  * ^definition = "The organization providing this service."
 

--- a/input/fsh/jurisdiction.fsh
+++ b/input/fsh/jurisdiction.fsh
@@ -7,22 +7,51 @@ Profile:      MCSDJurisdictionOrganization
 Parent:       MCSDOrganization
 Id:           IHE.mCSD.JurisdictionOrganization
 Title:        "mCSD Organization for Jurisdictions"
-Description:  "A profile on the mCSD Organization for mCSD Jurisdictions"
+Description:  """
+A profile on the mCSD Organization for mCSD Jurisdictions.
+
+Jurisdictions are political administrative units or other territories over which authority is exercised. A Jurisdiction
+has a unique identifier, geographic attributes, etc. Jurisdictions include political administrative units such as village
+districts or regions.  Each Jurisdiction is defined by a pairing of [Location](StructureDefinition-IHE.mCSD.JurisdictionLocation.html)
+and [Organization](StructureDefinition-IHE.mCSD.JurisdictionOrganization.html).
+
+"""
 
 * obeys mcsd-type-2
 * type 2..*
+  * ^short = "One type must be set to: urn:ietf:rfc:3986#urn:ihe:iti:mcsd:2019:jurisdiction"
+  * ^definition = "One type must be set to: urn:ietf:rfc:3986#urn:ihe:iti:mcsd:2019:jurisdiction"
 
 Profile:      MCSDJurisdictionLocation
 Parent:       MCSDLocation
 Id:           IHE.mCSD.JurisdictionLocation
 Title:        "mCSD Location for Jurisdictions"
-Description:  "A profile on the mCSD Location for mCSD Jurisdictions"
+Description:  """
+A profile on the mCSD Location for mCSD Jurisdictions.
+
+Jurisdictions are political administrative units or other territories over which authority is exercised. A Jurisdiction
+has a unique identifier, geographic attributes, etc. Jurisdictions include political administrative units such as village
+districts or regions.  Each Jurisdiction is defined by a pairing of [Location](StructureDefinition-IHE.mCSD.JurisdictionLocation.html)
+and [Organization](StructureDefinition-IHE.mCSD.JurisdictionOrganization.html).
+
+"""
 
 * obeys mcsd-type-2
 * type 2..*
+  * ^short = "One type must be set to: urn:ietf:rfc:3986#urn:ihe:iti:mcsd:2019:jurisdiction"
+  * ^definition = "One type must be set to: urn:ietf:rfc:3986#urn:ihe:iti:mcsd:2019:jurisdiction"
 * managingOrganization 1..1 
 * managingOrganization only Reference(MCSDJurisdictionOrganization)
+  * ^short = "The reference to the mCSD Organization resource for this jurisdiction."
+  * ^definition = "The reference to the mCSD Organization resource for this jurisdiction."
 * extension contains $BOUNDARY named boundary 0..1
+* extension[boundary]
+  * ^short = "When a boundary is available, the location-boundary-geojson extension should be used."
+  * ^definition = "When a boundary is available, the location-boundary-geojson extension should be used with the given url, contentType, and data."
 * extension[boundary].valueAttachment 1..1
-* extension[boundary].valueAttachment.contentType = #application/geo+json
+* extension[boundary].valueAttachment.contentType = #application/geo+json (exactly)
+  * ^short = "The boundary contentType shall be application/geo+json."
+  * ^definition = "The boundary contentType shall be application/geo+json."
 * extension[boundary].valueAttachment.data 1..1
+  * ^short = "The boundary data shall be in the valueAttachment data element."
+  * ^definition = "The boundary data shall be in the valueAttachment data element."

--- a/input/fsh/location.fsh
+++ b/input/fsh/location.fsh
@@ -2,17 +2,40 @@ Profile:      MCSDLocation
 Parent:       Location
 Id:           IHE.mCSD.Location
 Title:        "mCSD Location"
-Description:  "A profile on the Location resource for mCSD."
+Description:  """
+A profile on the Location resource for mCSD.
+
+Locations are physical places where care can be delivered such as facilities, buildings, wards,
+rooms, or vehicles. Locations also include jurisdictions such as a village districts or regions.
+A Location has a unique identifier and may have geographic attributes (address, geocode),
+attributes regarding its hours of operation, etc. Each Location may be related to one [Organization](StructureDefinition-IHE.mCSD.Organization.html).
+A location may have a hierarchical relationship with other locations.
+"""
 
 * type 1..*
+  * ^short = "A code that describes the type of Location."
+  * ^definition = "A code that describes the type of Location."
 * physicalType 1..1
+  * ^short = "A code that describes the physical form of the Location."
+  * ^definition = "A code that describes the physical form of the Location."
 * name 1..1
+  * ^short = "The name of the Location."
+  * ^definition = "The name of the Location."
 * status 1..1
+  * ^short = "The status code of the Location."
+  * ^definition = "The status code of the Location:  `active | suspended | inactive`"
+* partOf only Reference(MCSDLocation)
 
 Profile:      MCSDLocationDistance
 Parent:       MCSDLocation
 Id:           IHE.mCSD.LocationDistance
 Title:        "mCSD Location with Distance"
-Description:  "A profile on the mCSD Location resource for distance searches."
+Description:  """
+A profile on the mCSD Location resource for distance searches.
+
+This profile is for when you want to allow distance based searches for an mCSD Location resource.
+"""
 
 * position 1..1
+  * ^short = "The geographic point of the Location."
+  * ^definition = "The geographic point of the Location."

--- a/input/fsh/organization.fsh
+++ b/input/fsh/organization.fsh
@@ -2,18 +2,35 @@ Profile:      MCSDOrganization
 Parent:       Organization
 Id:           IHE.mCSD.Organization
 Title:        "mCSD Organization"
-Description:  "A profile on the Organization resource for mCSD."
+Description:  """
+A profile on the Organization resource for mCSD.
+
+Organizations are “umbrella” entities; these may be consideredthe administrative bodies under whose auspices
+care services are provided such as Healthcare Information Exchanges (HIEs), Integrated Delivery Networks
+(IDNs), Non-Government Organizations (NGOs), Faith-Based Organizations (FBOs) or even a one-physician family
+practice. An organization has a unique identifier and may have additional administrative attributes such as
+contact person, mailing address, etc. Departments of an institution, or other administrative units, may be
+represented as child Organizations of a parent Organization.
+"""
 
 * type 1..*
+  * ^short = "A code that describes the type of Organization."
+  * ^definition = "A code that describes the type of Organization."
 * name 1..1
-* partOf 0..1
+  * ^short = "The name of the Organization."
+  * ^definition = "The name of the Organization."
+* partOf only Reference(MCSDOrganization)
+  * ^short = "If the Organization belongs to a single hierarchy, the partOf element shall be used."
+  * ^definition = "If the Organization belongs to a single hierarchy, the partOf element shall be used."
 * extension contains MCSDOrganizationHierarchy named hierarchy 0..* 
-
+* extension[hierarchy]
+  * ^short = "If there are additional hierarchies (such as funding source), include them in this extension."
+  * ^definition = "If there are additional hierarchies (such as funding source), include them in this extension."
 
 Extension:    MCSDOrganizationHierarchy
 Id:           IHE.mCSD.OrganizationHierarchy
 Title:        "mCSD Additional Hierarchies extension for mCSD Organization."
-Description:  "If there are additional hierarchies (such as funding source),then use this extension."
+Description:  "If there are additional hierarchies (such as funding source), then use this extension."
 
 * ^context.type = #element
 * ^context.expression = "Organization"
@@ -22,15 +39,22 @@ Description:  "If there are additional hierarchies (such as funding source),then
             part-of 1..1
 * extension[hierarchy-type].value[x] only CodeableConcept
 * extension[hierarchy-type].valueCodeableConcept 1..1
+  * ^short = "A code for the type of the hierarchy."
+  * ^definition = "A code for the type of the hierarchy."
 * extension[part-of].value[x] only Reference(MCSDOrganization)
 * extension[part-of].valueReference 1..1
+  * ^short = "The parent mCSD organization in this hierarchy."
+  * ^definition = "The parent mCSD organization in this hierarchy."
 
 Instance:     MCSDSearchOrganizationHierarchyType
 InstanceOf:   SearchParameter
 Title:        "Search on the IHE defined extension for hierarchy type."
 * url = "http://profiles.ihe.net/ITI/mCSD/SearchParameter/IHE.mCSD.Organization.HierarchyType"
 * id = "IHE.mCSD.Organization.HierarchyType"
-* description = "This Search Parameter enables finding Organizations by the hierarchy type."
+* description = """
+This Search Parameter enables finding [Organizations](StructureDefinition-IHE.mCSD.Organization.html) by the
+[mCSD extension](StructureDefinition-IHE.mCSD.OrganizationHierarchy.html) hierarchy type.
+"""
 * name = "IHE_mCSD_Hierarchy_Type"
 * status = #active
 * code = #ihe-mcsd-hierarchy-type
@@ -43,7 +67,11 @@ InstanceOf:   SearchParameter
 Title:        "Search on the IHE defined extension for hierarchy part of."
 * url = "http://profiles.ihe.net/ITI/mCSD/SearchParameter/IHE.mCSD.Organization.HierarchyPartOf"
 * id = "IHE.mCSD.Organization.HierarchyPartOf"
-* description = "This Search Parameter enables finding Organizations by the hierarchy part of."
+* description = """
+This Search Parameter enables finding [Organizations](StructureDefinition-IHE.mCSD.Organization.html)
+by the hierarchy [mCSD extension](StructureDefinition-IHE.mCSD.OrganizationHierarchy.html) part of.
+"""
+
 * name = "IHE_mCSD_Hierarchy_PartOf"
 * status = #active
 * code = #ihe-mcsd-hierarchy-partof
@@ -52,4 +80,3 @@ Title:        "Search on the IHE defined extension for hierarchy part of."
 * expression = "extension('http://profiles.ihe.net/ITI/mCSD/StructureDefinition/IHE.mCSD.OrganizationHierarchy').extension('part-of').value as Reference"
 * modifier[+] = #below
 * modifier[+] = #above
-

--- a/input/fsh/practitioner.fsh
+++ b/input/fsh/practitioner.fsh
@@ -2,14 +2,48 @@ Profile:      MCSDPractitioner
 Parent:       Practitioner
 Id:           IHE.mCSD.Practitioner
 Title:        "mCSD Practitioner"
-Description:  "A profile on the Practitioner resource for mCSD."
+Description:  """
+A profile on the Practitioner resource for mCSD.
+
+A Practitioner is a [health worker such as defined by WHO](http://www.who.int/whr/2006/06_chap1_en.pdf); a Practitioner 
+might be a physician, nurse, pharmacist, community health worker, district health manager, etc. Practitioners have
+contact and demographic attributes. Each Practitioner may be related to one or more
+[Organizations](StructureDefinition-IHE.mCSD.Organization.html), one or more
+[Locations](StructureDefinition-IHE.mCSD.Location.html)
+and one or more [Healthcare Services](StructureDefinition-IHE.mCSD.HealthcareService.html) through a
+[Practitioner Role](StructureDefinition-IHE.mCSD.PractitionerRole.html). Specific attributes may be associated with
+the Practitioner relationship with these other entities.
+"""
 
 * name 1..*
+  * ^short = "The name of the Practitioner."
+  * ^definition = "The name of the Practitioner."
 
 Profile:      MCSDPractitionerRole
 Parent:       PractitionerRole
 Id:           IHE.mCSD.PractitionerRole
 Title:        "mCSD PractitionerRole"
-Description:  "A profile on the PractitionerRole resource for mCSD."
+Description:  """
+A profile on the PractitionerRole resource for mCSD.
+
+A PractitionerRole links a [Practitioner](StructureDefinition-IHE.mCSD.Practitioner.html) with a particular
+health care role to perform [Healthcare Services](StructureDefinition-IHE.mCSD.HealthcareService.html)
+at a particular [Location](StructureDefinition-IHE.mCSD.Location.html)
+for an [Organization](StructureDefinition-IHE.mCSD.Organization.html)
+"""
 
 * code 1..*
+  * ^short = "The roles the Practitioner performs."
+  * ^definition = "The roles the Practitioner performs."
+* practitioner only Reference(MCSDPractitioner)
+  * ^short = "The Practitioner that performs this role."
+  * ^definition = "The Practitioner that performs this role."
+* organization only Reference(MCSDOrganization)
+  * ^short = "The Organization where the roles are available."
+  * ^definition = "The Organization where the roles are available."
+* location only Reference(MCSDLocation)
+  * ^short = "The Location where the Practitioner provides care."
+  * ^definition = "The Location where the Practitioner provides care."
+* healthcareService only Reference(MCSDHealthcareService)
+  * ^short = "The HealthcareServices provided by this Practitioner at an Organization and/or Location."
+  * ^definition = "The HealthcareServices provided by this Practitioner at an Organization and/or Location."

--- a/input/pagecontent/ITI-90.md
+++ b/input/pagecontent/ITI-90.md
@@ -261,190 +261,77 @@ to the client.
 A Care Services Selective Consumer may query on Organization Resources.
 A Care Services Selective Supplier shall return a Bundle of matching
 Organization Resources. The Organization Resource shall be further
-constrained as described in Table 2:3.90.4.2.2.1-1 and in the
+constrained as described in the
 [Organization Profile for mCSD](StructureDefinition-IHE.mCSD.Organization.html).
-The Element column in Table 2:3.90.4.2.2.1-1 references the object model defined at
-[http://hl7.org/fhir/R4/organization.html#resource](http://hl7.org/fhir/R4/organization.html#resource).
-
-<a name="table2.3.90.4.2.2.1-1"></a>**Table 2:3.90.4.2.2.1-1: Organization Resource Constraints**
-
-| Element &amp; Cardinality | Data Type |
-| ------------------------- | --------- |
-| `type`<br />`[1..*]` | A code that describes the type of Organization.<br />`CodeableConcept` |
-| `name`<br />`[1..1]` | `string` |
-| `partOf`<br />`[0..1]` | If the Organization belongs to a single hierarchy, the partOf element shall be used.<br />`Reference (Organization)` |
-| `extension`<br />`[0..*]` | If there are additional hierarchies (such as funding source), include them in the extension with the following details:<br />Set the url to the canonical URI for this extension<br />`url = "http://profiles.ihe.net/ITI/mCSD/StructureDefinition/IHE.mCSD.OrganizationHierarchy"`<br />Set the sub-extension values<br />`hierarchy-type = valueCodeableConcept`<br />`part-of = valueReference(Organization)` |
-{: .grid .table-striped}
 
 A Care Services Selective Consumer may query on Organization Resources
 when working with Facilities. A Care Services Selective Supplier shall
 return a Bundle of matching Organization Resources when working with
-Facilities. In addition to the constraints in Table 2:3.90.4.2.2.1-1, the
-FHIR Organization Resource shall be further constrained as described in
-Table 2:3.90.4.2.2.1-2 and in the [Organization for Facilities Profile for mCSD](StructureDefinition-IHE.mCSD.FacilityOrganization.html).
-The Element column in Table 2:3.90.4.2.2.1-2
-references the object model defined at
-[http://hl7.org/fhir/R4/organization.html#resource](http://hl7.org/fhir/R4/organization.html#resource).
+Facilities. The FHIR Organization Resource shall be further constrained as described in the
+[Organization for Facilities Profile for mCSD](StructureDefinition-IHE.mCSD.FacilityOrganization.html).
 
-<a name="table2.3.90.4.2.2.1-2"></a>**Table 2:3.90.4.2.2.1-2: Additional Organization Resource Constraints for
-Facilities**
-
-| Element &amp; Cardinality | Data Type |
-| ------------------------- | --------- |
-| `type`<br />`[2..*]` | In addition, there shall be one type with the following value:<br />`system = "urn:ietf:rfc:3986"`<br />`code = "urn:ihe:iti:mcsd:2019:facility"` |
-{: .grid .table-striped}
-
-A Care Services Selective Consumer may query on Organization Resources when 
-working with Jurisdictions. A Care Services Selective Supplier shall return a 
-Bundle of matching Organization Resources when working with Jurisdictions. In 
-addition to the constraints in Table 3.90.4.2.2.1-1, the FHIR Organization Resource 
-shall be further constrained as described in Table 3.90.4.2.2.1-3
-and in the [Organization for Jurisdictions Profile for mCSD](StructureDefinition-IHE.mCSD.JurisdictionOrganization.html).
-The Element column in Table 3.90.4.2.2.1-3 references the object model defined at 
-[http://hl7.org/fhir/R4/organization.html#resource](http://hl7.org/fhir/R4/organization.html#resource).
-
-<a name="table2.3.90.4.2.2.1-3"></a>**Table 2:3.90.4.2.2.1-3: Additional Organization Resource Constraints for
-Jurisdictions**
-
-| Element &amp; Cardinality | Data Type |
-| ------------------------- | --------- |
-| `type`<br />`[2..*]` | In addition, there shall be one type with the following value:<br />`system = "urn:ietf:rfc:3986"`<br />`code = "urn:ihe:iti:mcsd:2019:jurisdiction"` |
-{: .grid .table-striped}
+A Care Services Selective Consumer may query on Organization Resources when
+working with Jurisdictions. A Care Services Selective Supplier shall return a
+Bundle of matching Organization Resources when working with Jurisdictions. The
+FHIR Organization Resource shall be further constrained as described in the
+[Organization for Jurisdictions Profile for mCSD](StructureDefinition-IHE.mCSD.JurisdictionOrganization.html).
 
 ###### 2:3.90.4.2.2.2 FHIR Location Resource Constraints
 
 A Care Services Selective Consumer may query on Location Resources. A
 Care Services Selective Supplier shall return a Bundle of matching
 Location Resources. The Location Resource shall be further constrained
-as described in Table 2:3.90.4.2.2.2-1 and in the [Location Profile for mCSD](StructureDefinition-IHE.mCSD.Location.html).
-The Element column in Table
-2:3.90.4.2.2.2-1 references the object model defined at
-[http://hl7.org/fhir/R4/location.html#resource](http://hl7.org/fhir/R4/location.html#resource).
-
-<a name="table2.3.90.4.2.2.2-1"></a>**Table 2:3.90.4.2.2.2-1: Location Resource Constraints**
-
-| Element &amp; Cardinality | Data Type |
-| ------------------------- | --------- |
-| `type`<br />`[1..*]` | A code that describes the type of Location.<br />`CodeableConcept` |
-| `physicalType`<br />`[1..1]` | A code that describes the physical type of Location.<br />`CodeableConcept` |
-| `name`<br />`[1..1]` | `string` |
-| `status`<br />`[1..1]` | `code (active| suspended| inactive)` |
-{: .grid .table-striped}
+as described in the [Location Profile for mCSD](StructureDefinition-IHE.mCSD.Location.html).
 
 When the resource is a Facility, the Location Resource shall be paired
 with an Organization Resource using the managingOrganization element in
 Location. A Care Services Selective Consumer may query on Location
 Resources when working with Facilities. A Care Services Selective
 Supplier shall return a Bundle of matching Location Resources when
-working with Facilities. In addition to the constraints in Table
-2:3.90.4.2.2.2-1, the FHIR Location Resource shall be further constrained
-as described in Table 2:3.90.4.2.2.2-2 and in the [Location for Facilities Profile for mCSD](StructureDefinition-IHE.mCSD.FacilityLocation.html).
-The Element column in Table 2:3.90.4.2.2.2-2 references the object model defined at
-[http://hl7.org/fhir/R4/location.html#resource](http://hl7.org/fhir/R4/location.html#resource).
-
-<a name="table2.3.90.4.2.2.2-2"></a>**Table 2:3.90.4.2.2.2-2: Additional Location Resource Constraints for
-Facilities**
-
-| Element &amp; Cardinality | Data Type |
-| ------------------------- | --------- |
-| `type`<br />`[2..*]` | In addition, there shall be one type with the following value:<br />`system = "urn:ietf:rfc:3986"`<br />`code = "urn:ihe:iti:mcsd:2019:facility"` |
-| `managingOrganization`<br />`[1..1]` | The reference to the Organization resource for this facility.<br />`Reference(Organization)` |
-{: .grid .table-striped}
+working with Facilities. The FHIR Location Resource shall be further constrained
+as described in the [Location for Facilities Profile for mCSD](StructureDefinition-IHE.mCSD.FacilityLocation.html).
 
 When the resource is a Jurisdiction, the Location Resource shall be paired with an Organization
 Resource using the managingOrganization element in Location. A Care Services Selective Consumer 
 may query on Location Resources when working with Jurisdictions. A Care Services Selective Supplier 
-shall return a Bundle of matching Location Resources when working with Jurisdictions. In addition to 
-the constraints in Table 3.90.4.2.2.2-1, the FHIR Location Resource shall be further constrained as 
-described in Table 3.90.4.2.2.2-3 and in the [Location for Jurisdictions Profile for mCSD](StructureDefinition-IHE.mCSD.JurisdictionLocation.html).
-The Element column in Table 3.90.4.2.2.2-3 references the object 
-model defined at [http://hl7.org/fhir/R4/location.html#resource](http://hl7.org/fhir/R4/location.html#resource).  
+shall return a Bundle of matching Location Resources when working with Jurisdictions. The FHIR Location Resource shall be further constrained as 
+described in the [Location for Jurisdictions Profile for mCSD](StructureDefinition-IHE.mCSD.JurisdictionLocation.html).
 
 When a geographic boundary is available for the Jurisdiction Location, the location-boundary-geojson extension defined at 
 [http://hl7.org/fhir/extension-location-boundary-geojson.html](http://hl7.org/fhir/extension-location-boundary-geojson.html) shall be used to store this information.
 
-<a name="table2.3.90.4.2.2.2-3"></a>**Table 2:3.90.4.2.2.2-3: Additional Location Resource Constraints for
-Jurisdictions**
-
-| Element &amp; Cardinality | Data Type |
-| ------------------------- | --------- |
-| `extension`<br />`[0..1]` | When a boundary is available, the location-boundary-geojson extension should be used with the given url, contentType, and data:<br />`url = http://hl7.org/fhir/StructureDefinition/location-boundary-geojson`<br />`valueAttachment.contentType = "application/geo+json"`<br />`valueAttachment.data = base64 encoded GeoJSON boundary data` |
-| `type`<br />`[2..*]` | In addition, there shall be one type with the following value:<br />`system = "urn:ietf:rfc:3986"`<br />`code = "urn:ihe:iti:mcsd:2019:jurisdiction"` |
-| `managingOrganization`<br />`[1..1]` | The reference to the Organization resource for this jurisdiction.<br />`Reference(Organization)` |
-{: .grid .table-striped}
-
 When supporting the Location Distance Option. The Location Resource
-shall be further constrained as described in Table 2:3.90.4.2.2.2-4 and in the 
+shall be further constrained as described in the 
 [Location with Distance Option Profile for mCSD](StructureDefinition-IHE.mCSD.LocationDistance.html).
-The Element column in Table 2:3.90.4.2.2.2-4 references the object model
-defined at [http://hl7.org/fhir/R4/location.html#resource](http://hl7.org/fhir/R4/location.html#resource).
-
-<a name="table2.3.90.4.2.2.2-4"></a>**Table 2:3.90.4.2.2.2-4: Location Resource Constraints with Location
-Distance Option**
-
-| Element &amp; Cardinality | Data Type |
-| ------------------------- | --------- |
-| `position`<br />`[1..1]` | `BackboneElement` |
-{: .grid .table-striped}
 
 ###### 2:3.90.4.2.2.3 FHIR Practitioner Resource Constraints
 
 A Care Services Selective Consumer may query on Practitioner Resources.
 A Care Services Selective Supplier shall return a Bundle of matching
 Practitioner Resources. The Practitioner Resource shall be further
-constrained as described in Table 2:3.90.4.2.2.3-1 and in the 
+constrained as described in the 
 [Practitioner Profile for mCSD](StructureDefinition-IHE.mCSD.Practitioner.html).
-The Element column in Table 2:3.90.4.2.2.3-1 references the object model defined at
-[http://hl7.org/fhir/R4/practitioner.html#resource](http://hl7.org/fhir/R4/practitioner.html#resource).
-
-<a name="table2.3.90.4.2.2.3-1"></a>**Table 2:3.90.4.2.2.3-1: Practitioner Resource Constraints**
-
-| Element &amp; Cardinality | Data Type |
-| ------------------------- | --------- |
-| `name`<br />`[1..*]` | `HumanName` |
-{: .grid .table-striped}
 
 ###### 2:3.90.4.2.2.4 FHIR PractitionerRole Resource Constraints
 
 A Care Services Selective Consumer may query on PractitionerRole
 Resources. A Care Services Selective Supplier shall return a Bundle of
 matching PractitionerRole Resources. The PractitionerRole Resource shall
-be further constrained as described in Table 2:3.90.4.2.2.4-1 and in the 
+be further constrained as described in the 
 [PractitionerRole Profile for mCSD](StructureDefinition-IHE.mCSD.PractitionerRole.html).
-The Element column in Table 2:3.90.4.2.2.4-1 references the object model defined at
-[http://hl7.org/fhir/R4/practitionerrole.html#resource](http://hl7.org/fhir/R4/practitionerrole.html#resource).
-
-<a name="table2.3.90.4.2.2.4-1"></a>**Table 2:3.90.4.2.2.4-1: PractitionerRole Resource Constraints**
-
-| Element &amp; Cardinality | Data Type |
-| ------------------------- | --------- |
-| `code`<br />`[1..*]` | `CodeableConcept` |
-{: .grid .table-striped}
 
 ###### 2:3.90.4.2.2.5 FHIR HealthcareService Resource Constraints
 
 A Care Services Selective Consumer may query on HealthcareService
 Resources. A Care Services Selective Supplier shall return a Bundle of
 matching HealthcareService Resources. The HealthcareService Resource
-shall be further constrained as described in Table 2:3.90.4.2.2.5-1 and
-in the [HealthcareService Profile for mCSD](StructureDefinition-IHE.mCSD.HealthcareService.html).
-The Element column in Table 2:3.90.4.2.2.5-1 references the object model
-defined at [http://hl7.org/fhir/R4/healthcareservice.html#resource](http://hl7.org/fhir/R4/healthcareservice.html#resource).
-
-<a name="table2.3.90.4.2.2.5-1"></a>**Table 2:3.90.4.2.2.5-1: HealthcareService Resource Constraints**
-
-| Element &amp; Cardinality | Data Type |
-| ------------------------- | --------- |
-| `type`<br />[1..*]` | `CodeableConcept` |
-| `name`<br />`[1..1]` | `string` |
-{: .grid .table-striped}
+shall be further constrained as described in the
+[HealthcareService Profile for mCSD](StructureDefinition-IHE.mCSD.HealthcareService.html).
 
 ##### 2:3.90.4.2.3 Expected Actions
 
 The Care Services Selective Consumer has received the response and
 continues with its workflow.
-
-
 
 #### 2:3.90.4.3 Retrieve Care Services Resource message
 This message represents an HTTP GET from the Care Services Selective Consumer to the Care Services Selective

--- a/input/pagecontent/ITI-91.md
+++ b/input/pagecontent/ITI-91.md
@@ -116,94 +116,57 @@ following Resources:
 
 A Care Services Update Consumer and a Care Services Update Supplier
 shall query or return an Organization Resource. The Organization
-Resource shall be further constrained as described in [Table
-3.90.4.2.2.1-1](ITI-90.html#table2.3.90.4.2.2.1-1) and in the
+Resource shall be further constrained as described in the
 [Organization Profile for mCSD](StructureDefinition-IHE.mCSD.Organization.html).
-The Element column in [Table 3.90.4.2.2.1-1](ITI-90.html#table2.3.90.4.2.2.1-1) references
-the object model defined at
-[http://hl7.org/fhir/R4/organization.html#resource](http://hl7.org/fhir/R4/organization.html#resource).
 
 When the Organization represents a Facility and is paired with a
 Location, the FHIR Organization Resource shall be further constrained as
-described in [Table 3.90.4.2.2.1-2](ITI-90.html#table2.3.90.4.2.2.1-2) and in the 
+described in the
 [Organization for Facilities Profile for mCSD](StructureDefinition-IHE.mCSD.FacilityOrganization.html).
-The Element column in [Table 3.90.4.2.2.1-2](ITI-90.html#table2.3.90.4.2.2.1-2)
-references the object model defined at
-[http://hl7.org/fhir/R4/organization.html#resource](http://hl7.org/fhir/R4/organization.html#resource).
 
 When the Organization represents a Jurisdiction and is paired with a Location,
-the FHIR Organization Resource shall be further constrained as described in
-[Table 3.90.4.2.2.1-3](ITI-90.html#table2.3.90.4.2.2.1-3)and in the
+the FHIR Organization Resource shall be further constrained as described in the
 [Organization for Jurisdictions Profile for mCSD](StructureDefinition-IHE.mCSD.JurisdictionOrganization.html).
-The Element column in [Table 3.90.4.2.2.1-3](ITI-90.html#table2.3.90.4.2.2.1-3) references the 
-object model defined at [http://hl7.org/fhir/R4/organization.html#resource](http://hl7.org/fhir/R4/organization.html#resource).
 
 ###### 2:3.91.4.2.2.2 FHIR Location Resource Constraints
 
 A Care Services Update Consumer and a Care Services Update Supplier
 shall query or return a Location Resource. The Location Resource shall
-be further constrained as described in [Table 3.90.4.2.2.2-1](ITI-90.html#table2.3.90.4.2.2.2-1)
-and in the [Location Profile for mCSD](StructureDefinition-IHE.mCSD.Location.html).
-The Element column in [Table 3.90.4.2.2.2-1](ITI-90.html#table2.3.90.4.2.2.2-1) references
-the object model defined at
-[http://hl7.org/fhir/R4/location.html#resource](http://hl7.org/fhir/R4/location.html#resource).
+be further constrained as described in the [Location Profile for mCSD](StructureDefinition-IHE.mCSD.Location.html).
 
 When the Location represents a Facility and is paired with an
 Organization, the FHIR Location Resource shall be further constrained as
-described in [Table 3.90.4.2.2.2-2](ITI-90.html#table2.3.90.4.2.2.2-2) and in the 
+described in the 
 [Location for Facilities Profile for mCSD](StructureDefinition-IHE.mCSD.FacilityLocation.html).
-The Element column in [Table 3.90.4.2.2.2-2](ITI-90.html#table2.3.90.4.2.2.2-2)
-references the object model defined at
-[http://hl7.org/fhir/R4/location.html#resource](http://hl7.org/fhir/R4/location.html#resource).
 
 When the Location represents a Jurisdiction and is paired with an Organization, the FHIR 
-Location Resource shall be further constrained as described in 
-[Table 3.90.4.2.2.2-3](ITI-90.html#table2.3.90.4.2.2.2-3)
-and in the [Location for Jurisdictions Profile for mCSD](StructureDefinition-IHE.mCSD.JurisdictionLocation.html).
-The Element column in [Table 3.90.4.2.2.2-3](ITI-90.html#table2.3.90.4.2.2.2-3)
-references the object model defined at
-[http://hl7.org/fhir/R4/location.html#resource](http://hl7.org/fhir/R4/location.html#resource).
+Location Resource shall be further constrained as described in the
+[Location for Jurisdictions Profile for mCSD](StructureDefinition-IHE.mCSD.JurisdictionLocation.html).
 
 When supporting the Location Distance Option, the FHIR Location Resource
-shall be further constrained as described in 
-[Table 3.90.4.2.2.2-4](ITI-90.html#table2.3.90.4.2.2.2-4) and in the
+shall be further constrained as described in the
 [Location with Distance Option Profile for mCSD](StructureDefinition-IHE.mCSD.LocationDistance.html).
-The Element column in [Table 3.90.4.2.2.2-4](ITI-90.html#table2.3.90.4.2.2.2-4)
-references the object model defined at 
-[http://hl7.org/fhir/R4/location.html#resource](http://hl7.org/fhir/R4/location.html#resource).
 
 ###### 2:3.91.4.2.2.3 FHIR Practitioner Resource Constraints
 
 A Care Services Update Consumer and a Care Services Update Supplier
 shall query or return a Practitioner Resource. The Practitioner Resource
-shall be further constrained as described in 
-[Table 3.90.4.2.2.3-1](ITI-90.html#table2.3.90.4.2.2.3-1) and in the 
+shall be further constrained as described in the
 [Practitioner Profile for mCSD](StructureDefinition-IHE.mCSD.Practitioner.html).
-The Element column in [Table 3.90.4.2.2.3-1](ITI-90.html#table2.3.90.4.2.2.3-1)
-references the object model defined at
-[http://hl7.org/fhir/R4/practitioner.html#resource](http://hl7.org/fhir/R4/practitioner.html#resource).
 
 ###### 2:3.91.4.2.2.4 FHIR PractitionerRole Resource Constraints
 
 A Care Services Update Consumer and a Care Services Update Supplier
 shall query or return a PractitionerRole Resource. The PractitionerRole
-Resource shall be further constrained as described in
-[Table 3.90.4.2.2.4-1](ITI-90.html#table2.3.90.4.2.2.4-1) and in the
+Resource shall be further constrained as described in the
 [PractitionerRole Profile for mCSD](StructureDefinition-IHE.mCSD.PractitionerRole.html).
-The Element column in [Table 3.90.4.2.2.4-1](ITI-90.html#table2.3.90.4.2.2.4-1) references
-the object model defined at
-[http://hl7.org/fhir/R4/practitionerrole.html#resource](http://hl7.org/fhir/R4/practitionerrole.html#resource).
 
 ###### 2:3.91.4.2.2.5 FHIR HealthcareService Resource Constraints
 
 A Care Services Update Consumer and a Care Services Update Supplier
 shall query or return a HealthcareService Resource. The
-HealthcareService Resource shall be further constrained as described in
-[Table 3.90.4.2.2.5-1](ITI-90.html#table2.3.90.4.2.2.5-1) and in the
+HealthcareService Resource shall be further constrained as described in the
 [HealthcareService Profile for mCSD](StructureDefinition-IHE.mCSD.HealthcareService.html).
-The Element column in [Table 3.90.4.2.2.5-1](ITI-90.html#table2.3.90.4.2.2.5-1)
-references the object model defined at
-[http://hl7.org/fhir/R4/healthcareservice.html#resource](http://hl7.org/fhir/R4/healthcareservice.html#resource).
 
 ##### 2:3.91.4.2.3 Expected Actions
 

--- a/input/pagecontent/issues.md
+++ b/input/pagecontent/issues.md
@@ -11,16 +11,16 @@
 - Added in text to show that searches can use GET or POST [ITI-90 Message Semantics](ITI-90.html#2390412-message-semantics).
 - Added in retrieve (GET RESOURCE/ID) message section starting at [ITI-90](ITI-90.html#239043-retrieve-care-services-resource-message)
 - Removed tables:
--- Table 2:3.90.4.2.2.1-1 to [Organization Profile for mCSD](StructureDefinition-IHE.mCSD.Organization.html)
--- Table 2:3.90.4.2.2.1-2 to [Organization for Facilities Profile for mCSD](StructureDefinition-IHE.mCSD.FacilityOrganization.html)
--- Table 2:3.90.4.2.2.1-3 to [Organization for Jurisdictions Profile for mCSD](StructureDefinition-IHE.mCSD.JurisdictionOrganization.html)
--- Table 2:3.90.4.2.2.2-1 to [Location Profile for mCSD](StructureDefinition-IHE.mCSD.Location.html)
--- Table 2:3.90.4.2.2.2-2 to [Location for Facilities Profile for mCSD](StructureDefinition-IHE.mCSD.FacilityLocation.html)
--- Table 2:3.90.4.2.2.2-3 to [Location for Jurisdictions Profile for mCSD](StructureDefinition-IHE.mCSD.JurisdictionLocation.html)
--- Table 2:3.90.4.2.2.2-4 to [Location with Distance Option Profile for mCSD](StructureDefinition-IHE.mCSD.LocationDistance.html)
--- Table 2:3.90.4.2.2.3-1 to [Practitioner Profile for mCSD](StructureDefinition-IHE.mCSD.Practitioner.html)
--- Table 2:3.90.4.2.2.4-1 to [PractitionerRole Profile for mCSD](StructureDefinition-IHE.mCSD.PractitionerRole.html)
--- Table 2:3.90.4.2.2.5-1 to [HealthcareService Profile for mCSD](StructureDefinition-IHE.mCSD.HealthcareService.html)
+  - Table 2:3.90.4.2.2.1-1 to [Organization Profile for mCSD](StructureDefinition-IHE.mCSD.Organization.html)
+  - Table 2:3.90.4.2.2.1-2 to [Organization for Facilities Profile for mCSD](StructureDefinition-IHE.mCSD.FacilityOrganization.html)
+  - Table 2:3.90.4.2.2.1-3 to [Organization for Jurisdictions Profile for mCSD](StructureDefinition-IHE.mCSD.JurisdictionOrganization.html)
+  - Table 2:3.90.4.2.2.2-1 to [Location Profile for mCSD](StructureDefinition-IHE.mCSD.Location.html)
+  - Table 2:3.90.4.2.2.2-2 to [Location for Facilities Profile for mCSD](StructureDefinition-IHE.mCSD.FacilityLocation.html)
+  - Table 2:3.90.4.2.2.2-3 to [Location for Jurisdictions Profile for mCSD](StructureDefinition-IHE.mCSD.JurisdictionLocation.html)
+  - Table 2:3.90.4.2.2.2-4 to [Location with Distance Option Profile for mCSD](StructureDefinition-IHE.mCSD.LocationDistance.html)
+  - Table 2:3.90.4.2.2.3-1 to [Practitioner Profile for mCSD](StructureDefinition-IHE.mCSD.Practitioner.html)
+  - Table 2:3.90.4.2.2.4-1 to [PractitionerRole Profile for mCSD](StructureDefinition-IHE.mCSD.PractitionerRole.html)
+  - Table 2:3.90.4.2.2.5-1 to [HealthcareService Profile for mCSD](StructureDefinition-IHE.mCSD.HealthcareService.html)
 
 ## Issues
 

--- a/input/pagecontent/issues.md
+++ b/input/pagecontent/issues.md
@@ -10,6 +10,17 @@
 - Changed structuredefinitions for Facility and Jurisdiction to use an invariant for the type requirement instead of slicing.
 - Added in text to show that searches can use GET or POST [ITI-90 Message Semantics](ITI-90.html#2390412-message-semantics).
 - Added in retrieve (GET RESOURCE/ID) message section starting at [ITI-90](ITI-90.html#239043-retrieve-care-services-resource-message)
+- Removed tables:
+-- Table 2:3.90.4.2.2.1-1 to [Organization Profile for mCSD](StructureDefinition-IHE.mCSD.Organization.html)
+-- Table 2:3.90.4.2.2.1-2 to [Organization for Facilities Profile for mCSD](StructureDefinition-IHE.mCSD.FacilityOrganization.html)
+-- Table 2:3.90.4.2.2.1-3 to [Organization for Jurisdictions Profile for mCSD](StructureDefinition-IHE.mCSD.JurisdictionOrganization.html)
+-- Table 2:3.90.4.2.2.2-1 to [Location Profile for mCSD](StructureDefinition-IHE.mCSD.Location.html)
+-- Table 2:3.90.4.2.2.2-2 to [Location for Facilities Profile for mCSD](StructureDefinition-IHE.mCSD.FacilityLocation.html)
+-- Table 2:3.90.4.2.2.2-3 to [Location for Jurisdictions Profile for mCSD](StructureDefinition-IHE.mCSD.JurisdictionLocation.html)
+-- Table 2:3.90.4.2.2.2-4 to [Location with Distance Option Profile for mCSD](StructureDefinition-IHE.mCSD.LocationDistance.html)
+-- Table 2:3.90.4.2.2.3-1 to [Practitioner Profile for mCSD](StructureDefinition-IHE.mCSD.Practitioner.html)
+-- Table 2:3.90.4.2.2.4-1 to [PractitionerRole Profile for mCSD](StructureDefinition-IHE.mCSD.PractitionerRole.html)
+-- Table 2:3.90.4.2.2.5-1 to [HealthcareService Profile for mCSD](StructureDefinition-IHE.mCSD.HealthcareService.html)
 
 ## Issues
 


### PR DESCRIPTION
This has removed the constraint tables and copied the content to the structure definitions in the FSH files.