### PR TITLE
Fix copy-paste mistake in Volume 1

### DIFF
--- a/input/pagecontent/volume-1.md
+++ b/input/pagecontent/volume-1.md
@@ -134,7 +134,7 @@ A Directory that supports the Update Option SHALL implement the [Request Care Se
 
 ### 1:46.2.3 Feed Option
 
-The Feed Option enables the Directory from receiving feed updates from the Feed Client.
+The Feed Option enables the Directory to receive feed updates from the Feed Client.
 
 A Directory that supports the Feed Option SHALL implement the [Care Services Feed [ITI-130]](ITI-130.html) transaction.
 

--- a/input/pagecontent/volume-1.md
+++ b/input/pagecontent/volume-1.md
@@ -134,9 +134,9 @@ A Directory that supports the Update Option SHALL implement the [Request Care Se
 
 ### 1:46.2.3 Feed Option
 
-The Feed Option enables receiving feed updates from the Feed Client from the Directory.
+The Feed Option enables the Directory from receiving feed updates from the Feed Client.
 
-A Directory that supports the Update Option SHALL implement the [Request Care Services Updates [ITI-91]](ITI-91.html) transaction.
+A Directory that supports the Feed Option SHALL implement the [Care Services Feed [ITI-130]](ITI-130.html) transaction.
 
 ## 1:46.3 mCSD Required Actor Groupings
 


### PR DESCRIPTION

## 📑 Description
There's a copy-paste mistake in Volume 1, the description of _1:46.2.2 Update Option_ and _1:46.2.3 Feed Option_ are almost the same.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
- [ ] I have selected a committee co-chair to review the PR

## ℹ Additional Information