### PR TITLE
Update feed transaction to allow some of the messages to be optional …

### DIFF
--- a/input/fsh/IHE.mCSD.DataSource.fsh
+++ b/input/fsh/IHE.mCSD.DataSource.fsh
@@ -27,7 +27,7 @@ Usage: #definition
       * insert Expectation(SHALL)
       * code = #update
     * interaction[+]
-      * insert Expectation(SHALL)
+      * insert Expectation(MAY)
       * code = #delete
   * resource[+]
     * insert Expectation(MAY)
@@ -44,7 +44,7 @@ Usage: #definition
       * insert Expectation(SHALL)
       * code = #update
     * interaction[+]
-      * insert Expectation(SHALL)
+      * insert Expectation(MAY)
       * code = #delete
   * resource[+]
     * insert Expectation(MAY)
@@ -60,7 +60,7 @@ Usage: #definition
       * insert Expectation(SHALL)
       * code = #update
     * interaction[+]
-      * insert Expectation(SHALL)
+      * insert Expectation(MAY)
       * code = #delete
   * resource[+]
     * insert Expectation(MAY)
@@ -74,7 +74,7 @@ Usage: #definition
       * insert Expectation(SHALL)
       * code = #update
     * interaction[+]
-      * insert Expectation(SHALL)
+      * insert Expectation(MAY)
       * code = #delete
   * resource[+]
     * insert Expectation(MAY)
@@ -88,7 +88,7 @@ Usage: #definition
       * insert Expectation(SHALL)
       * code = #update
     * interaction[+]
-      * insert Expectation(SHALL)
+      * insert Expectation(MAY)
       * code = #delete
   * resource[+]
     * insert Expectation(MAY)
@@ -103,7 +103,7 @@ Usage: #definition
       * insert Expectation(SHALL)
       * code = #update
     * interaction[+]
-      * insert Expectation(SHALL)
+      * insert Expectation(MAY)
       * code = #delete
   * resource[+]
     * insert Expectation(MAY)
@@ -118,8 +118,8 @@ Usage: #definition
       * insert Expectation(SHALL)
       * code = #update
     * interaction[+]
-      * insert Expectation(SHALL)
+      * insert Expectation(MAY)
       * code = #delete
   * interaction[+]
-    * insert Expectation(SHALL)
+    * insert Expectation(MAY)
     * code = #transaction

--- a/input/fsh/IHE.mCSD.Directory.Feed.fsh
+++ b/input/fsh/IHE.mCSD.Directory.Feed.fsh
@@ -27,7 +27,7 @@ Usage: #definition
       * insert Expectation(SHALL)
       * code = #update
     * interaction[+]
-      * insert Expectation(SHALL)
+      * insert Expectation(MAY)
       * code = #delete
   * resource[+]
     * insert Expectation(MAY)
@@ -44,7 +44,7 @@ Usage: #definition
       * insert Expectation(SHALL)
       * code = #update
     * interaction[+]
-      * insert Expectation(SHALL)
+      * insert Expectation(MAY)
       * code = #delete
   * resource[+]
     * insert Expectation(MAY)
@@ -60,7 +60,7 @@ Usage: #definition
       * insert Expectation(SHALL)
       * code = #update
     * interaction[+]
-      * insert Expectation(SHALL)
+      * insert Expectation(MAY)
       * code = #delete
   * resource[+]
     * insert Expectation(MAY)
@@ -74,7 +74,7 @@ Usage: #definition
       * insert Expectation(SHALL)
       * code = #update
     * interaction[+]
-      * insert Expectation(SHALL)
+      * insert Expectation(MAY)
       * code = #delete
   * resource[+]
     * insert Expectation(MAY)
@@ -88,7 +88,7 @@ Usage: #definition
       * insert Expectation(SHALL)
       * code = #update
     * interaction[+]
-      * insert Expectation(SHALL)
+      * insert Expectation(MAY)
       * code = #delete
   * resource[+]
     * insert Expectation(MAY)
@@ -103,7 +103,7 @@ Usage: #definition
       * insert Expectation(SHALL)
       * code = #update
     * interaction[+]
-      * insert Expectation(SHALL)
+      * insert Expectation(MAY)
       * code = #delete
   * resource[+]
     * insert Expectation(MAY)
@@ -118,7 +118,7 @@ Usage: #definition
       * insert Expectation(SHALL)
       * code = #update
     * interaction[+]
-      * insert Expectation(SHALL)
+      * insert Expectation(MAY)
       * code = #delete
   * interaction[+]
     * insert Expectation(SHALL)

--- a/input/pagecontent/ITI-130.md
+++ b/input/pagecontent/ITI-130.md
@@ -27,7 +27,8 @@ The Care Services Feed transaction is used to create, update, or delete care ser
 
 #### 2:3.130.4.1 Create Care Services Resource Request Message
 
-A Create Care Services Resource Request Message is a FHIR create operation on any supported Care Services resource the Directory supports.
+A Create Care Services Resource Request Message is a FHIR create operation on any supported Care Services resource the Directory supports.  
+The Data Source and Directory actors SHALL support this message.
 
 ##### 2:3.130.4.1.1 Trigger Events
 
@@ -120,6 +121,7 @@ The Data Source has received the response and continues with its workflow.
 #### 2:3.130.4.3 Update Care Services Resource Request Message
 
 A Update Care Services Resource Request Message is a FHIR update operation on any supported Care Services resource the Directory supports.
+The Data Source and Directory actors SHALL support this message.
 
 ##### 2:3.130.4.3.1 Trigger Events
 
@@ -211,6 +213,16 @@ The Data Source has received the response and continues with its workflow.
 #### 2:3.130.4.5 Delete Care Services Resource Request Message
 
 A Delete Care Services Resource Request Message is a FHIR delete operation on any supported Care Services resource the Directory supports.
+This message is optional for both the Data Source and Directory actors.
+
+Care Services Resources support `.status` or `.active` elements to identify whether or not those Resources are currently valid.
+
+In many cases, managing Resources using those elements is preferable to inactivating with the HTTP DELETE interaction.
+
+1. Inactivating, rather than deleting, makes maintaining referential integrity in the Directory and in dependent systems easier as existing data can reference an Inactive entry.
+1. Inactivating makes it easier to discover historic entries
+
+Directory policy should consider if the delete message or an update message to deactivate resources should be used and support this message or not accordingly.
 
 ##### 2:3.130.4.5.1 Trigger Events
 
@@ -255,6 +267,8 @@ A Process Care Services Resources Request Message is a FHIR transaction operatio
 - [Create Care Services Resource Request Message](#2313041-create-care-services-resource-request-message)
 - [Update Care Services Resource Request Message](#2313043-update-care-services-resource-request-message)
 - [Delete Care Services Resource Request Message](#2313045-delete-care-services-resource-request-message)
+
+The Directory actor SHALL support this message.  The Data Source MAY support this message.
 
 ##### 2:3.130.4.7.1 Trigger Events
 


### PR DESCRIPTION
…depending on the actor.  Fixes #206.  Fixes #205.

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #205 
Closes #206 

## 📑 Description
Updated the Feed Transaction messages so that Create/Update are required by both actors.  Delete is optional for both with a message regarding status/active elements.  Transaction is required for the Directory and optional for the Data Source.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
- [x] I have selected a committee co-chair to review the PR

